### PR TITLE
Add a command to authorize an user with role editable permissions

### DIFF
--- a/lib/hybrid_blog/release.ex
+++ b/lib/hybrid_blog/release.ex
@@ -15,4 +15,21 @@ defmodule HybridBlog.Release do
     version = Keyword.fetch!(options, :version)
     {:ok, _, _} = Ecto.Migrator.with_repo(repo, &Ecto.Migrator.run(&1, :down, to: version))
   end
+
+  def authorize_first_user(_argv) do
+    {:ok, _} = Application.ensure_all_started(:ssl)
+    :ok = Application.load(@app)
+
+    {:ok, _, _} =
+      Ecto.Migrator.with_repo(HybridBlog.Repo, fn repo ->
+        script =
+          Path.join([
+            :code.priv_dir(@app),
+            repo |> Module.split() |> List.last() |> Macro.underscore(),
+            "authorize_first_user.exs"
+          ])
+
+        if File.exists?(script), do: Code.eval_file(script)
+      end)
+  end
 end

--- a/priv/repo/authorize_first_user.exs
+++ b/priv/repo/authorize_first_user.exs
@@ -1,0 +1,9 @@
+alias HybridBlog.Repo
+alias HybridBlog.Accounts.User
+alias HybridBlog.Accounts.Role
+import Ecto.Query, only: [from: 2]
+import Ecto.Changeset, only: [change: 1, put_assoc: 3]
+
+[user] = Repo.all(from User, preload: :roles)
+role = Repo.insert!(%Role{name: "Admin", permissions: ["list_roles", "edit_roles"]})
+change(user) |> put_assoc(:roles, [role | user.roles]) |> Repo.update!()

--- a/rel/commands/authorize_first_user.sh
+++ b/rel/commands/authorize_first_user.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+info "seeding user roles"
+release_ctl eval --mfa "HybridBlog.Release.authorize_first_user/1" --argv -- "$@"
+success "seeding completed"

--- a/rel/config.exs
+++ b/rel/config.exs
@@ -49,5 +49,12 @@ end
 release :hybrid_blog do
   set(version: current_version(:hybrid_blog))
   set(applications: [:runtime_tools])
-  set(commands: [migrate: "rel/commands/migrate.sh", rollback: "rel/commands/rollback.sh"])
+
+  set(
+    commands: [
+      migrate: "rel/commands/migrate.sh",
+      rollback: "rel/commands/rollback.sh",
+      authorize_first_user: "rel/commands/authorize_first_user.sh"
+    ]
+  )
 end


### PR DESCRIPTION
When the app is created, we have to create an administrative user.
This command enables to create and attach a role with listing and editing role permissions.

1. Sign in with OAuth. There must be just one account in the Web App.
2. Run `authorize_first_user` distillery command. On Gigalixir for example,
   ```sh
   gigalixir ps:distillery authorize_first_user
   ```

Then the user can access the role list view.