### PR TITLE
Continue seeding even if the application is already loaded

### DIFF
--- a/lib/hybrid_blog/release.ex
+++ b/lib/hybrid_blog/release.ex
@@ -18,7 +18,7 @@ defmodule HybridBlog.Release do
 
   def authorize_first_user(_argv) do
     {:ok, _} = Application.ensure_all_started(:ssl)
-    :ok = Application.load(@app)
+    :ok = Application.ensure_loaded(@app)
 
     {:ok, _, _} =
       Ecto.Migrator.with_repo(HybridBlog.Repo, fn repo ->

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule HybridBlog.MixProject do
   def project do
     [
       app: :hybrid_blog,
-      version: "0.1.7",
+      version: "0.1.8",
       elixir: "~> 1.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),


### PR DESCRIPTION
The application is already loaded when running distillery commands on the production environment.
`Application.load/1` -> `Application.ensure_loaded/1`